### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
         branches: [master]
 
+permissions:
+    contents: read
+
 jobs:
     test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ArturN31/bookstore/security/code-scanning/3](https://github.com/ArturN31/bookstore/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define it at the workflow root (applies to all jobs unless overridden), using the minimal permission CodeQL recommends for this workflow: `contents: read`.

**File to change:** `.github/workflows/test.yml`  
**Change location:** after the `on:` trigger block and before `jobs:`.  
**No imports, methods, or dependencies** are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
